### PR TITLE
feat: Take serializer when registering a recipe

### DIFF
--- a/fabric/src/main/java/net/blay09/mods/balm/fabric/recipe/FabricBalmRecipes.java
+++ b/fabric/src/main/java/net/blay09/mods/balm/fabric/recipe/FabricBalmRecipes.java
@@ -6,6 +6,7 @@ import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 
 import java.util.function.Supplier;
@@ -13,9 +14,10 @@ import java.util.function.Supplier;
 public class FabricBalmRecipes implements BalmRecipes {
 
     @Override
-    public <T extends Recipe<?>> DeferredObject<RecipeType<T>> registerRecipeType(Supplier<RecipeType<T>> supplier, ResourceLocation identifier) {
+    public <T extends Recipe<?>> DeferredObject<RecipeType<T>> registerRecipeType(Supplier<RecipeType<T>> typeSupplier, Supplier<RecipeSerializer<T>> serializerSupplier, ResourceLocation identifier) {
         return new DeferredObject<>(identifier, () -> {
-            RecipeType<T> recipeType = supplier.get();
+            Registry.register(BuiltInRegistries.RECIPE_SERIALIZER, identifier, serializerSupplier.get());
+            RecipeType<T> recipeType = typeSupplier.get();
             recipeType = Registry.register(BuiltInRegistries.RECIPE_TYPE, identifier, recipeType);
             return recipeType;
         }).resolveImmediately();

--- a/forge/src/main/java/net/blay09/mods/balm/forge/recipe/ForgeBalmRecipes.java
+++ b/forge/src/main/java/net/blay09/mods/balm/forge/recipe/ForgeBalmRecipes.java
@@ -5,6 +5,7 @@ import net.blay09.mods.balm.api.recipe.BalmRecipes;
 import net.blay09.mods.balm.forge.DeferredRegisters;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -14,10 +15,14 @@ import java.util.function.Supplier;
 
 public class ForgeBalmRecipes implements BalmRecipes {
     @Override
-    public <T extends Recipe<?>> DeferredObject<RecipeType<T>> registerRecipeType(Supplier<RecipeType<T>> supplier, ResourceLocation identifier) {
-        DeferredRegister<RecipeType<?>> register = DeferredRegisters.get(ForgeRegistries.RECIPE_TYPES, identifier.getNamespace());
-        RegistryObject<RecipeType<T>> registryObject = register.register(identifier.getPath(), supplier);
-        return new DeferredObject<>(identifier, registryObject, registryObject::isPresent);
+    public <T extends Recipe<?>> DeferredObject<RecipeType<T>> registerRecipeType(Supplier<RecipeType<T>> typeSupplier, Supplier<RecipeSerializer<T>> serializerSupplier, ResourceLocation identifier) {
+        DeferredRegister<RecipeSerializer<?>> serializerRegister = DeferredRegisters.get(ForgeRegistries.RECIPE_SERIALIZERS, identifier.getNamespace());
+        RegistryObject<RecipeSerializer<T>> serializerObject = serializerRegister.register(identifier.getPath(), serializerSupplier);
+
+        DeferredRegister<RecipeType<?>> typeRegister = DeferredRegisters.get(ForgeRegistries.RECIPE_TYPES, identifier.getNamespace());
+        RegistryObject<RecipeType<T>> typeObject = typeRegister.register(identifier.getPath(), typeSupplier);
+
+        return new DeferredObject<>(identifier, typeObject, () -> typeObject.isPresent() && serializerObject.isPresent());
     }
 
 }

--- a/neoforge/src/main/java/net/blay09/mods/balm/neoforge/recipe/NeoForgeBalmRecipes.java
+++ b/neoforge/src/main/java/net/blay09/mods/balm/neoforge/recipe/NeoForgeBalmRecipes.java
@@ -6,16 +6,21 @@ import net.blay09.mods.balm.neoforge.DeferredRegisters;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 
 import java.util.function.Supplier;
 
 public class NeoForgeBalmRecipes implements BalmRecipes {
     @Override
-    public <T extends Recipe<?>> DeferredObject<RecipeType<T>> registerRecipeType(Supplier<RecipeType<T>> supplier, ResourceLocation identifier) {
+    public <T extends Recipe<?>> DeferredObject<RecipeType<T>> registerRecipeType(Supplier<RecipeType<T>> typeSupplier, Supplier<RecipeSerializer<T>> serializerSupplier, ResourceLocation identifier) {
         final var register = DeferredRegisters.get(Registries.RECIPE_TYPE, identifier.getNamespace());
-        final var registryObject = register.register(identifier.getPath(), supplier);
-        return new DeferredObject<>(identifier, registryObject, registryObject::isBound);
+        final var registryObject = register.register(identifier.getPath(), typeSupplier);
+
+        final var serializerRegister = DeferredRegisters.get(Registries.RECIPE_SERIALIZER, identifier.getNamespace());
+        final var serializerRegistryObject = serializerRegister.register(identifier.getPath(), serializerSupplier);
+
+        return new DeferredObject<>(identifier, registryObject, () -> registryObject.isBound() && serializerRegistryObject.isBound());
     }
 
 }

--- a/shared/src/main/java/net/blay09/mods/balm/api/Balm.java
+++ b/shared/src/main/java/net/blay09/mods/balm/api/Balm.java
@@ -12,6 +12,7 @@ import net.blay09.mods.balm.api.menu.BalmMenus;
 import net.blay09.mods.balm.api.network.BalmNetworking;
 import net.blay09.mods.balm.api.provider.BalmProviders;
 import net.blay09.mods.balm.api.proxy.SidedProxy;
+import net.blay09.mods.balm.api.recipe.BalmRecipes;
 import net.blay09.mods.balm.api.sound.BalmSounds;
 import net.blay09.mods.balm.api.stats.BalmStats;
 import net.blay09.mods.balm.api.world.BalmWorldGen;
@@ -97,6 +98,10 @@ public class Balm {
 
     public static BalmHooks getHooks() {
         return runtime.getHooks();
+    }
+
+    public static BalmRecipes getRecipes() {
+        return runtime.getRecipes();
     }
 
     public static BalmRegistries getRegistries() {

--- a/shared/src/main/java/net/blay09/mods/balm/api/recipe/BalmRecipes.java
+++ b/shared/src/main/java/net/blay09/mods/balm/api/recipe/BalmRecipes.java
@@ -3,10 +3,11 @@ package net.blay09.mods.balm.api.recipe;
 import net.blay09.mods.balm.api.DeferredObject;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 
 import java.util.function.Supplier;
 
 public interface BalmRecipes {
-    <T extends Recipe<?>> DeferredObject<RecipeType<T>> registerRecipeType(Supplier<RecipeType<T>> supplier, ResourceLocation identifier);
+    <T extends Recipe<?>> DeferredObject<RecipeType<T>> registerRecipeType(Supplier<RecipeType<T>> typeSupplier, Supplier<RecipeSerializer<T>> serializerSupplier, ResourceLocation identifier);
 }


### PR DESCRIPTION
The `RecipeSerializer` is actually the one thing coded by the user, and goes hand in hand
with the `RecipeType` itself.

This commit also exposes the `BalmRecipes` API through `Balm`, which has access to the
runtime.