### PR TITLE
Skip writing `BalmData` tag to entity if empty

### DIFF
--- a/fabric/src/main/java/net/blay09/mods/balm/mixin/EntityMixin.java
+++ b/fabric/src/main/java/net/blay09/mods/balm/mixin/EntityMixin.java
@@ -28,7 +28,7 @@ public class EntityMixin implements BalmEntity {
 
     @Inject(method = "saveWithoutId(Lnet/minecraft/nbt/CompoundTag;)Lnet/minecraft/nbt/CompoundTag;", at = @At("HEAD"))
     private void saveWithoutId(CompoundTag compound, CallbackInfoReturnable<CompoundTag> callbackInfo) {
-        compound.put("BalmData", balmData);
+        if (balmData.size() != 0) compound.put("BalmData", balmData);
     }
 
     @Override


### PR DESCRIPTION
No idea if this works as-is but hopefully you get the idea. Your dependent mods which don't touch the block registry or anything shouldn't need to signal their presence to connecting clients.