### PR TITLE
Upgrade Gradle, Loom and ForgeGradle

### DIFF
--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -92,7 +92,7 @@ modrinth {
     projectId = findProperty("modrinth_project_id")
     versionType = "release"
     versionNumber = project.version + "+forge-" + libs.minecraft.get().version
-    uploadFile = jar.outputs.getFiles().asPath.replace(".jar", "-all.jar")
+    uploadFile = tasks.jarJar.archiveFile.get().asFile
     changelog = rootProject.file("CHANGELOG.md").text
     gameVersions = [libs.minecraft.get().version]
     syncBodyFrom = rootProject.file("modpage.md").text

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -3,90 +3,69 @@ import net.darkhax.curseforgegradle.TaskPublishCurseForge
 plugins {
     id 'multiloader-loader'
     alias libs.plugins.forgeGradle
-    alias libs.plugins.mixin
+    alias libs.plugins.forgeJarJar
     alias libs.plugins.curseForgeGradle
     alias libs.plugins.modrinthMinotaur
 }
 
-mixin {
-    config("${mod_id}.mixins.json")
-    config("${mod_id}.api.mixins.json")
-    config("${mod_id}.forge.mixins.json")
+java.toolchain.languageVersion = JavaLanguageVersion.of(21)
+
+jarJar.register()
+tasks.named('jar') {
+    archiveClassifier = 'slim'
+}
+tasks.named('jarJar') {
+    archiveClassifier = null
 }
 
-jarJar.enable()
-build.dependsOn tasks.jarJar
+minecraft {
+    mappings channel: 'official', version: libs.minecraft.get().version
+    runs {
+        configureEach {
+            workingDir.convention layout.projectDirectory.dir('run')
+            // Mixin requires either specifying the config via command line, or in the Manifest
+            args "--mixin.config=${mod_id}.mixins.json,${mod_id}-api.mixins.json,${mod_id}-forge.mixins.json"
+        }
+        register('client') {
+            systemProperty 'forge.enabledGameTestNamespaces', mod_id
+        }
+    }
+}
 
-jar {
+repositories {
+    maven minecraft.mavenizer
+    maven fg.forgeMaven
+    maven fg.minecraftLibsMaven
+    mavenCentral()
+}
+
+dependencies {
+    def mcVersion = libs.minecraft.get().version
+    def forgeVersion = libs.forge.get().version
+    implementation minecraft.dependency("net.minecraftforge:forge:$mcVersion-$forgeVersion")
+    annotationProcessor 'net.minecraftforge:eventbus-validator:7.0-beta.10'
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8' // Use the UTF-8 charset for Java compilation
+}
+
+tasks.named('jar', Jar) {
     manifest {
         attributes["MixinConfigs"] = "${mod_id}.mixins.json,${mod_id}.api.mixins.json,${mod_id}.forge.mixins.json"
     }
 }
 
-minecraft {
-    mappings channel: 'official', version: libs.minecraft.get().version
-
-    copyIdeResources = true //Calls processResources when in dev
-
-    reobf = false // Forge 1.20.6+ uses official mappings at runtime, so we shouldn't reobf from official to SRG
-
-    // Automatically enable forge AccessTransformers if the file exists
-    def at = file('src/main/resources/META-INF/accesstransformer.cfg')
-    if (at.exists()) {
-        accessTransformer = at
-    }
-
-    runs {
-        client {
-            workingDirectory file('runs/client')
-            ideaModule "${rootProject.name}.${project.name}.main"
-            taskName "Client"
-
-            property 'forge.enabledGameTestNamespaces', mod_id
-
-            mods {
-                modClientRun {
-                    source sourceSets.main
-                }
-            }
-        }
-
-        server {
-            workingDirectory file('runs/server')
-            ideaModule "${rootProject.name}.${project.name}.main"
-            taskName "Server"
-
-            property 'forge.enabledGameTestNamespaces', mod_id
-
-            mods {
-                modServerRun {
-                    source sourceSets.main
-                }
-            }
-        }
+fgtools {
+    configure('mavenizer') {
+        classpath = configurations.detachedConfiguration(dependencies.create('net.minecraftforge:minecraft-mavenizer:0.4.19'))
     }
 }
 
 sourceSets.main.resources.srcDir 'src/generated/resources'
 
-dependencies {
-    def mcVersion = libs.minecraft.get().version
-    def forgeVersion = libs.forge.get().version
-    minecraft "net.minecraftforge:forge:${mcVersion}-${forgeVersion}"
-    def mixinVersion = libs.mixin.get().version
-    annotationProcessor "org.spongepowered:mixin:${mixinVersion}:processor"
-}
-
 apply from: rootProject.file('repositories.gradle')
 apply from: 'dependencies.gradle'
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            fg.component(it)
-        }
-    }
-}
 
 tasks.register('curseforge', TaskPublishCurseForge) {
     dependsOn('build')
@@ -120,9 +99,3 @@ modrinth {
     loaders = ['forge']
 }
 tasks.modrinth.dependsOn(build)
-
-sourceSets.each {
-    def dir = layout.buildDirectory.dir("sourcesSets/$it.name")
-    it.output.resourcesDir = dir
-    it.java.destinationDirectory = dir
-}

--- a/forge/dependencies.gradle
+++ b/forge/dependencies.gradle
@@ -1,9 +1,6 @@
 dependencies {
     api libs.kumaForge
-    jarJar(group: "net.blay09.mods", name: "kuma-api-forge", version: kuma_version_range) {
-        jarJar.pin(it, libs.kumaForge.get().version)
-        transitive = false
-    }
+    jarJar("net.blay09.mods:kuma-api-forge:${libs.kumaForge.get().version}")
     compileOnly libs.jeiCommon
     compileOnly libs.wthitForge
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,9 +41,10 @@ curios = { module = "top.theillusivec4.curios:curios-neoforge", version = "9.5.1
 theOneProbe = { module = "curse.maven:the-one-probe-245211", version = "6106996" }
 
 [plugins]
-fabricLoom = { id = "fabric-loom", version = "1.13-SNAPSHOT" }
+fabricLoom = { id = "fabric-loom", version = "1.14-SNAPSHOT" }
 modDevGradle = { id = "net.neoforged.moddev", version = "2.0.124" }
-forgeGradle = { id = "net.minecraftforge.gradle", version = "[6.0.25,6.2)" }
+forgeGradle = { id = "net.minecraftforge.gradle", version = "7.0.0-rc.2" }
+forgeJarJar = { id = "net.minecraftforge.jarjar", version = "0.2.3" }
 mixin = { id = "org.spongepowered.mixin", version = "0.7-SNAPSHOT" }
 curseForgeGradle = { id = "net.darkhax.curseforgegradle", version = "1.1.26" }
 modrinthMinotaur = { id = "com.modrinth.minotaur", version = "2.+" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-rc-1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -40,7 +40,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
 
 includeBuild('build-logic')


### PR DESCRIPTION
Unfortunately this means all downstream mods also need to follow suit, but the combination of Mojang's `Identifier` rename and incompatibilities in the different build plugins make it impossible to stay on the more compatible older versions due to dependency constraints.